### PR TITLE
Revert "validate against whole configuration to detect duplicates"

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -12,7 +12,7 @@ define dnsmasq::conf (
     group        => 'root',
     content      => $content,
     source       => $source,
-    validate_cmd => "/usr/sbin/dnsmasq --test --conf-file=% --conf-file=${::dnsmasq::params::config_file}",
+    validate_cmd => '/usr/sbin/dnsmasq --test --conf-file=%',
     notify       => Class['dnsmasq::service'],
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class dnsmasq::config {
 
   file { $::dnsmasq::params::config_file:
     mode         => '0644',
-    validate_cmd => "/usr/sbin/dnsmasq --test --conf-file=% --conf-file=${::dnsmasq::params::config_file}",
+    validate_cmd => '/usr/sbin/dnsmasq --test --conf-file=%',
     source       => 'puppet:///modules/dnsmasq/dnsmasq.conf',
   }
 


### PR DESCRIPTION
I have to revert this as it causes kind of false positives.

The change introduces kind of a loop. Puppet will place a temporary file next to the active one and with the inclusion of **/etc/dnsmasq.conf** the whole directory **/etc/dnsmasq.d/** is checked which contins the active and temporary file at the same time which leads to duplication warnings and a failing validation.