### PR TITLE
ensure dnsmasq is installed before placing and validating config; fix…

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -14,5 +14,6 @@ define dnsmasq::conf (
     source       => $source,
     validate_cmd => '/usr/sbin/dnsmasq --test --conf-file=%',
     notify       => Class['dnsmasq::service'],
+    require      => Class['::dnsmasq::install'],
   }
 }


### PR DESCRIPTION
Currently the module fails on the first run as it attempts to place and validate the configuration given before dnsmasq is installed.
This PR fixes the issue.